### PR TITLE
Missing MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE README.md


### PR DESCRIPTION
When installing from `pip`, you get the following error:

```
with open('README.md') as f:
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
```